### PR TITLE
bridge_phy: add conditional compilation for linux 6.12

### DIFF
--- a/loonggpu-bridge/bridge_phy.c
+++ b/loonggpu-bridge/bridge_phy.c
@@ -759,6 +759,7 @@ struct loonggpu_bridge_phy *bridge_phy_alloc(struct loonggpu_dc_bridge *dc_bridg
 	struct connector_resource *connector_res =
 			dc_bridge->adev->dc->link_info[index].connector;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
 	bridge_phy = devm_drm_bridge_alloc(dc_bridge->adev->dev,
 					   struct loonggpu_bridge_phy,
 					   bridge, &bridge_funcs);
@@ -766,6 +767,13 @@ struct loonggpu_bridge_phy *bridge_phy_alloc(struct loonggpu_dc_bridge *dc_bridg
 		DRM_ERROR("Failed to alloc loonggpu bridge phy!\n");
 		return bridge_phy;
 	}
+#else
+	bridge_phy = devm_kzalloc(dc_bridge->adev->dev, sizeof(*bridge_phy), GFP_KERNEL);
+	if (!bridge_phy) {
+		DRM_ERROR("Failed to alloc loonggpu bridge phy!\n");
+		return bridge_phy;
+	}
+#endif
 
 	bridge_phy->display_pipe_index = dc_bridge->display_pipe_index;
 	bridge_phy->bridge.driver_private = bridge_phy;


### PR DESCRIPTION
Function `devm_drm_bridge_alloc()` was introduced in Linux 6.16. In previous version, we should use `devm_kzalloc()` instead of `devm_drm_bridge_alloc()`.

Refer to https://github.com/torvalds/linux/commit/0cc6aadd7fc1e629b715ea3d1ba537ef2da95eec